### PR TITLE
Engineering, janitor, and medical holosign projectors are much faster, and have a max capacity of 12. Their integrity have been reduced.

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -86,7 +86,7 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
-	creation_time = 20
+	creation_time = 6
 	max_signs = 12
 
 /obj/item/holosign_creator/security
@@ -102,8 +102,8 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 30
-	max_signs = 6
+	creation_time = 6
+	max_signs = 12
 
 /obj/item/holosign_creator/atmos
 	name = "ATMOS holofan projector"
@@ -118,8 +118,8 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 30
-	max_signs = 3
+	creation_time = 6
+	max_signs = 12
 
 /obj/item/holosign_creator/cyborg
 	name = "Energy Barrier Projector"

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -84,6 +84,7 @@
 	desc = "When it says walk it means walk."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "holosign"
+	max_integrity = 1
 
 /obj/structure/holosign/barrier/wetsign/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -97,6 +98,7 @@
 /obj/structure/holosign/barrier/engineering
 	icon_state = "holosign_engi"
 	rad_insulation = RAD_LIGHT_INSULATION
+	max_integrity = 1
 
 /obj/structure/holosign/barrier/atmos
 	name = "holofirelock"
@@ -150,6 +152,7 @@
 	desc = "A holobarrier that uses biometrics to detect human viruses. Denies passing to personnel with easily-detected, malicious viruses. Good for quarantines."
 	icon_state = "holo_medical"
 	alpha = 125 //lazy :)
+	max_integrity = 1
 	var/force_allaccess = FALSE
 	var/buzzcd = 0
 


### PR DESCRIPTION
Reduces janitor, engineering, and medical holosign creation time to 6 seconds. Increases max sign count of engineering and medical holobarriers to 12.

## About The Pull Request
Sets the holosign creation time for the engineering, janitor, and medical holosign projectors to 0.6 seconds. Increases engineering and medical holosign projector max capacity to 12. Engineering, janitorial, and medical holosign integrity have been reduced to 1.

## Why It's Good For The Game
Holosign projectors, especially the engineering ones (as the situation that warrents them is an emergency that does not have a lot of time to waste), are not used often. Their time to project was too long to be practical for an emergency, and a capacity of 6 is somewhat restrictive for what can warrent their usage.

Their integrity got reduced so hopefully they can't be used to Fortnite.

## Changelog

:cl:
balance: Engineering, janitorial and medical holosign projector projection time reduced to 0.6 seconds.
balance: Engineering and medical holosign projector max capacity increased to 12.
balance: Engineering, janitorial and medical holobarrier integrity reduced to 1.
/:cl:

